### PR TITLE
Use Librdkafka Package from Confluent Repositories

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,13 @@ RUN apt-get install -y cmake
 RUN apt-get install -y automake libtool
 
 # Install librdkafka.
-RUN apt-get install -y libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
+RUN apt-get install -y sudo
+RUN wget -qO - https://packages.confluent.io/deb/7.3/archive.key | sudo apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/7.3 stable main"
+RUN add-apt-repository "deb https://packages.confluent.io/clients/deb $(lsb_release -cs) main"
+RUN apt update
+RUN apt-get install -y libsasl2-modules libsasl2-modules-gssapi-mit libsasl2-dev libssl-dev 
+RUN apt install -y librdkafka-dev
 
 # Install pugixml
 ADD ./pugixml /asn1_codec/pugixml

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -20,7 +20,13 @@ RUN cd cmake-3.7.2 && ./bootstrap && make && make install && cd /home
 RUN apt-get update && apt-get install -y automake libtool
 
 # Install librdkafka.
-RUN apt-get install -y libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
+RUN apt-get install -y sudo
+RUN wget -qO - https://packages.confluent.io/deb/7.3/archive.key | sudo apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/7.3 stable main"
+RUN add-apt-repository "deb https://packages.confluent.io/clients/deb $(lsb_release -cs) main"
+RUN apt update
+RUN apt-get install -y libsasl2-modules libsasl2-modules-gssapi-mit libsasl2-dev libssl-dev 
+RUN apt install -y librdkafka-dev
 
 # Install pugixml
 ADD ./pugixml /asn1_codec/pugixml

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -14,7 +14,13 @@ RUN cd cmake-3.7.2 && ./bootstrap && make && make install && cd /home
 RUN apt-get update && apt-get install -y automake libtool
 
 # Install librdkafka.
-RUN apt-get install -y libsasl2-dev libsasl2-modules libssl-dev librdkafka-dev
+RUN apt-get install -y sudo
+RUN wget -qO - https://packages.confluent.io/deb/7.3/archive.key | sudo apt-key add -
+RUN add-apt-repository "deb [arch=amd64] https://packages.confluent.io/deb/7.3 stable main"
+RUN add-apt-repository "deb https://packages.confluent.io/clients/deb $(lsb_release -cs) main"
+RUN apt update
+RUN apt-get install -y libsasl2-modules libsasl2-modules-gssapi-mit libsasl2-dev libssl-dev 
+RUN apt install -y librdkafka-dev
 
 # Install pugixml
 ADD ./pugixml /asn1_codec/pugixml


### PR DESCRIPTION
## Changes
The changes in this PR make the dockerfiles for the project add Confluent's repositories before downloading librdkafka-dev.

This makes it possible to use the packaged version of librdkafka with both an on-prem instance of kafka as well as one hosted by Confluent Cloud.

This has been tested in both our dev and test environments.

## Reasoning
The developer of librdkafka, Edenhill, suggests using Confluent's repositories since the Ubuntu/Debian repository typically does not provide the latest version of librdkafka. (https://github.com/confluentinc/confluent-kafka-go/issues/360)

## Relevant Links
- https://docs.confluent.io/4.0.1/installation/installing_cp.html#debian-and-ubuntu
- https://docs.confluent.io/4.0.1/installation/available_packages.html#available-packages
