### PR TITLE
Logging Modifications - AcmLogger Class

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -9,6 +9,13 @@ TICK="[${GREEN}✓${NC}]"
 CROSS="[${RED}✗${NC}]"
 INFO="[${CYAN}i${NC}]"
 
+initializeSubmodules(){
+    # initialize submodules
+    echo "${GREEN}Initializing submodules${NC}"
+    git submodule update --recursive --init
+    git pull --recurse-submodules
+}
+
 buildAsn1c(){
     # build asn1c
     echo "${GREEN}Building asn1c${NC}"
@@ -66,6 +73,7 @@ runTests() {
 
 runAll(){
     # following from instructions in installation.md, this is the proper build order
+    initializeSubmodules
     buildAsn1c
     buildPugiXml
     compileSpecAndBuildLibrary

--- a/build_local.sh
+++ b/build_local.sh
@@ -20,6 +20,7 @@ buildAsn1c(){
     # build asn1c
     echo "${GREEN}Building asn1c${NC}"
     cd ./asn1c
+    git reset --hard
     git pull origin master
     aclocal
     test -f ./configure || autoreconf -iv

--- a/docker-compose-confluent-cloud.yml
+++ b/docker-compose-confluent-cloud.yml
@@ -10,6 +10,8 @@ services:
       CONFLUENT_KEY: ${CONFLUENT_KEY}
       CONFLUENT_SECRET: ${CONFLUENT_SECRET}
       ACM_CONFIG_FILE: adm.properties
+      ACM_LOG_TO_CONSOLE: "true"
+      ACM_LOG_TO_FILE: "false"
   aem:
     build:
       context: .
@@ -20,3 +22,5 @@ services:
       CONFLUENT_KEY: ${CONFLUENT_KEY}
       CONFLUENT_SECRET: ${CONFLUENT_SECRET}
       ACM_CONFIG_FILE: aem.properties
+      ACM_LOG_TO_CONSOLE: "true"
+      ACM_LOG_TO_FILE: "false"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -25,3 +25,9 @@ services:
       - kafka
     links:
       - kafka
+    environment:
+      DOCKER_HOST_IP: ${DOCKER_HOST_IP}
+      KAFKA_TYPE: "ON-PREM"
+      ACM_CONFIG_FILE: adm.properties
+      ACM_LOG_TO_CONSOLE: "true"
+      ACM_LOG_TO_FILE: "false"

--- a/include/acm.hpp
+++ b/include/acm.hpp
@@ -60,9 +60,10 @@
 #include "Ieee1609Dot2Data.h"
 #include "AdvisorySituationData.h"
 #include "tool.hpp"
-#include "spdlog/spdlog.h"
 #include "librdkafka/rdkafkacpp.h"
 #include "pugixml.hpp"
+
+#include "acmLogger.hpp"
 
 #include <deque>
 #include <utility>
@@ -201,8 +202,7 @@ class ASN1_Codec : public tool::Tool {
 
     public:
 
-        std::shared_ptr<spdlog::logger> ilogger;
-        std::shared_ptr<spdlog::logger> elogger;
+        std::shared_ptr<AcmLogger> logger;
 
         static void sigterm (int sig);
 

--- a/include/acmLogger.hpp
+++ b/include/acmLogger.hpp
@@ -1,0 +1,53 @@
+#ifndef ACM_LOGGER_H
+#define ACM_LOGGER_H
+
+#include <string>
+#include "spdlog/spdlog.h"
+
+#include <iostream>
+
+/**
+ * @brief The AcmLogger class is intended to be an abstraction layer for the utilization
+ * of the spdlog library and to make logging to a file and/or the console configurable.
+ */
+class AcmLogger {
+    public:
+        AcmLogger(std::string ilogname, std::string elogname);
+
+        void set_info_level(spdlog::level::level_enum level);
+        void set_error_level(spdlog::level::level_enum level);
+        void set_info_pattern(const std::string& pattern);
+        void set_error_pattern(const std::string& pattern);
+        
+        void info(const std::string& message);
+        void error(const std::string& message);
+        void trace(const std::string& message);
+        void critical(const std::string& message);
+        void warn(const std::string& message);
+
+        void flush();
+
+    private:
+        long INFO_LOG_SIZE = 1048576 * 5;                   ///> The size of a single information log; these rotate.
+        long ERROR_LOG_SIZE = 1048576 * 2;                   ///> The size of a single error log; these rotate.
+        int INFO_LOG_NUM = 5;                               ///> The number of information logs to rotate.
+        int ERROR_LOG_NUM = 2;                               ///> The number of error logs to rotate.
+    
+        spdlog::level::level_enum iloglevel = spdlog::level::trace;     ///> Log level for the information log.
+        spdlog::level::level_enum eloglevel = spdlog::level::err;       ///> Log level for the error log.
+        
+        std::shared_ptr<spdlog::logger> ilogger;
+        std::shared_ptr<spdlog::logger> elogger;
+
+        bool logToFileFlag;
+        bool logToConsoleFlag;
+
+        void setInfoLogger(std::shared_ptr<spdlog::logger> spdlog_logger);
+        void setErrorLogger(std::shared_ptr<spdlog::logger> spdlog_logger);
+        void initializeFlagValuesFromEnvironment();
+        const char* getEnvironmentVariable(std::string var);
+        std::string toLowercase(std::string str);
+        bool convertStringToBool(std::string str);
+};
+
+#endif

--- a/include/acm_blob_producer.hpp
+++ b/include/acm_blob_producer.hpp
@@ -51,14 +51,14 @@
 
 #include <librdkafka/rdkafkacpp.h>
 #include "tool.hpp"
-#include "spdlog/spdlog.h"
+
+#include "acmLogger.hpp"
 
 class ACMBlobProducer : public tool::Tool {
 
     public:
 
-        std::shared_ptr<spdlog::logger> ilogger;
-        std::shared_ptr<spdlog::logger> elogger;
+        std::shared_ptr<AcmLogger> logger;
 
         static void sigterm (int sig);
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -5,6 +5,7 @@ target_sources(acm PUBLIC
     "${CMAKE_CURRENT_LIST_DIR}/acm.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/tool.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/utilities.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/acmLogger.cpp"
     )
 
 # Include here all the relevant code for the above sources.
@@ -25,6 +26,7 @@ target_sources(acm_tests PUBLIC
     "${CMAKE_CURRENT_LIST_DIR}/acm.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/tool.cpp"
     "${CMAKE_CURRENT_LIST_DIR}/utilities.cpp"
+    "${CMAKE_CURRENT_LIST_DIR}/acmLogger.cpp"
     )
 
 target_include_directories(acm_tests PUBLIC

--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -204,8 +204,7 @@ ASN1_Codec::ASN1_Codec( const std::string& name, const std::string& description 
 	, decode_1609dot2_type{ATS_CANONICAL_OER}
 	, decode_messageframe_type{ATS_UNALIGNED_BASIC_PER}
 	, decode_asdframe_type{ATS_UNALIGNED_BASIC_PER}
-    , ilogger{}
-    , elogger{}
+    , logger{}
 {
 }
 
@@ -305,16 +304,16 @@ bool ASN1_Codec::topic_available( const std::string& topic ) {
             // finish when we find it.
             r = ( (*it)->topic() == topic );
             if ( r ) {
-                ilogger->info( "Topic: {} found in the kafka metadata.", topic );
+                logger->info("Topic: " + topic + " found in the kafka metadata.");
             }
             ++it;
         }
         if (!r) {
-            ilogger->warn( "Metadata did not contain topic: {}.", topic );
+            logger->warn("Metadata did not contain topic: " + topic);
         }
 
     } else {
-        elogger->error( "cannot retrieve consumer metadata with error: {}.", err2str(err) );
+        logger->error("cannot retrieve consumer metadata with error: " + err2str(err));
     }
 
     return r;
@@ -347,12 +346,12 @@ void ASN1_Codec::print_configuration() const {
 }
 
 bool ASN1_Codec::configure() {
-    static const char* fnname = "configure()";
+    const std::string fnname = "configure()";
     std::string line;
     std::string error_string;
     StrVector pieces;
 
-    ilogger->trace("{}: starting...", fnname );
+    logger->trace(fnname + ": starting...");
 
     // configurations; global and topic (the names in these are fixed)
     conf  = RdKafka::Conf::create(RdKafka::Conf::CONF_GLOBAL);
@@ -360,16 +359,16 @@ bool ASN1_Codec::configure() {
 
     // must use a configuration file.
     if ( !optIsSet('c') ) {
-        elogger->error( "{}: asked to use a configuration file, but option not set.", fnname  );
+        logger->error(fnname + ": asked to use a configuration file, but option not set.");
         return false;
     }
 
     const std::string& cfile = optString('c');              // needed for error message.
-    ilogger->trace("{}: using configuration file: {}", fnname , cfile );
+    logger->trace(fnname + ": using configuration file: " + cfile );
     std::ifstream ifs{ cfile };
 
     if (!ifs) {
-        elogger->error("{}: cannot open configuration file: {}", fnname , cfile);
+        logger->error(fnname + ": cannot open configuration file: " + cfile);
         return false;
     }
 
@@ -384,24 +383,24 @@ bool ASN1_Codec::configure() {
                 string_utilities::strip( pieces[1] );
                 // some of these configurations are stored in each...?? strange.
                 if ( tconf->set(pieces[0], pieces[1], error_string) == RdKafka::Conf::CONF_OK ) {
-                    ilogger->info("{}: kafka topic configuration: {} = {}", fnname , pieces[0], pieces[1]);
+                    logger->info(fnname + ": kafka topic configuration: " + pieces[0] + " = " + pieces[1]);
                     done = true;
                 }
 
                 if ( conf->set(pieces[0], pieces[1], error_string) == RdKafka::Conf::CONF_OK ) {
-                    ilogger->info("{}: kafka configuration: {} = {}", fnname , pieces[0], pieces[1]);
+                    logger->info(fnname + ": kafka configuration: " + pieces[0] + " = " + pieces[1]);
                     done = true;
                 }
 
                 if ( !done ) { 
-                    ilogger->info("{}: ASN1_Codec configuration: {} = {}", fnname , pieces[0], pieces[1]);
+                    logger->info(fnname + ": ASN1_Codec configuration: " + pieces[0] + " = " + pieces[1]);
                     // These configuration options are not expected by Kafka.
                     // Assume there are for the ASN1_Codec.
                     pconf[ pieces[0] ] = pieces[1];
                 }
 
             } else {
-                elogger->warn("{}: too many pieces in the configuration file line: {}", fnname , line);
+                logger->warn(fnname + ": too many pieces in the configuration file line: " + line);
             }
 
         } // otherwise: empty or comment line.
@@ -424,21 +423,21 @@ bool ASN1_Codec::configure() {
     
     if ( optIsSet('v') ) {
         if ( "trace" == optString('v') ) {
-            ilogger->set_level( spdlog::level::trace );
+            logger->set_info_level( spdlog::level::trace );
         } else if ( "debug" == optString('v') ) {
-            ilogger->set_level( spdlog::level::trace );
+            logger->set_info_level( spdlog::level::trace );
         } else if ( "info" == optString('v') ) {
-            ilogger->set_level( spdlog::level::trace );
+            logger->set_info_level( spdlog::level::trace );
         } else if ( "warning" == optString('v') ) {
-            ilogger->set_level( spdlog::level::warn );
+            logger->set_info_level( spdlog::level::warn );
         } else if ( "error" == optString('v') ) {
-            ilogger->set_level( spdlog::level::err );
+            logger->set_info_level( spdlog::level::err );
         } else if ( "critical" == optString('v') ) {
-            ilogger->set_level( spdlog::level::critical );
+            logger->set_info_level( spdlog::level::critical );
         } else if ( "off" == optString('v') ) {
-            ilogger->set_level( spdlog::level::off );
+            logger->set_info_level( spdlog::level::off );
         } else {
-            elogger->warn("information logger level was configured but unreadable; using default.");
+            logger->warn("information logger level was configured but unreadable; using default.");
         }
     } // else it is already set to default.
 
@@ -451,13 +450,13 @@ bool ASN1_Codec::configure() {
 
     pugi::xml_parse_result result = error_doc.load_file( errorfile.c_str() );
     if (!result) {
-        elogger->error("{}: Failure to find or parse the error template file: {} (offset = {})!", fnname , result.description(), result.offset);
+        logger->error(fnname + ": Failure to find or parse the error template file: " + result.description() + " (offset = " + std::to_string(result.offset) + ")!");
         return false;
     } 
 
     if ( optIsSet('b') ) {
         // broker specified.
-        ilogger->info("{}: setting kafka broker to: {}", fnname , optString('b'));
+        logger->info(fnname + ": setting kafka broker to: " + optString('b'));
         conf->set("metadata.broker.list", optString('b'), error_string);
     } 
 
@@ -472,7 +471,7 @@ bool ASN1_Codec::configure() {
         }  // otherwise leave at default; PARTITION_UA
     }
 
-    ilogger->info("{}: kafka partition: {}", fnname , partition);
+    logger->info(fnname + ": kafka partition: " + std::to_string(partition));
 
     // confluent cloud integration
     std::string kafkaType = getEnvironmentVariable("KAFKA_TYPE");
@@ -495,7 +494,7 @@ bool ASN1_Codec::configure() {
 
     if ( getOption('g').isSet() && conf->set("group.id", optString('g'), error_string) != RdKafka::Conf::CONF_OK) {
         // NOTE: there are some checks in librdkafka that require this to be present and set.
-        elogger->error("{}: kafka error setting configuration parameters group.id h: {}", fnname , error_string);
+        logger->error(fnname + ": kafka error setting configuration parameters group.id h: " + error_string);
         return false;
     }
 
@@ -513,14 +512,14 @@ bool ASN1_Codec::configure() {
             offset = strtoll(o.c_str(), NULL, 10);              // throws
         }
 
-        ilogger->info("{}: offset in partition set to byte: {}", fnname , o);
+        logger->info(fnname + ": offset in partition set to byte: " + o);
     }
 
     // Do we want to exit if a stream eof is sent.
     exit_eof = getOption('x').isSet();
 
     if (optIsSet('d') && conf->set("debug", optString('d'), error_string) != RdKafka::Conf::CONF_OK) {
-        elogger->error("{}: kafka error setting configuration parameter debug: {}", fnname , error_string);
+        logger->error(fnname + ": kafka error setting configuration parameter debug: " + error_string);
         return false;
     }
 
@@ -530,11 +529,11 @@ bool ASN1_Codec::configure() {
     search = pconf.find("asn1.topic.consumer");
     if ( search != pconf.end() ) {
         consumed_topics.push_back( search->second );
-        ilogger->info("{}: consumed topic: {}", fnname , search->second);
+        logger->info(fnname + ": consumed topic: " + search->second);
 
     } else {
         
-        elogger->error("{}: no consumer topic was specified; must fail.", fnname );
+        logger->error(fnname + ": no consumer topic was specified; must fail.");
         return false;
     }
 
@@ -548,23 +547,23 @@ bool ASN1_Codec::configure() {
         if ( search != pconf.end() ) {
             published_topic_name = search->second;
         } else {
-            elogger->error("{}: no publisher topic was specified; must fail.", fnname );
+            logger->error(fnname + ": no publisher topic was specified; must fail.");
             return false;
         }
     }
 
-    ilogger->info("{}: published topic: {}", fnname , published_topic_name);
+    logger->info(fnname + ": published topic: " + published_topic_name);
 
     search = pconf.find("asn1.consumer.timeout.ms");
     if ( search != pconf.end() ) {
         try {
             consumer_timeout = std::stoi( search->second );
         } catch( std::exception& e ) {
-            ilogger->info("{}: using the default consumer timeout value.", fnname );
+            logger->info(fnname + ": using the default consumer timeout value.");
         }
     }
 
-    ilogger->trace("{}: finished.", fnname );
+    logger->trace(fnname + ": finished.");
     return true;
 }
 
@@ -573,17 +572,17 @@ bool ASN1_Codec::launch_producer() {
 
     producer_ptr = std::shared_ptr<RdKafka::Producer>( RdKafka::Producer::create(conf, error_string) );
     if ( !producer_ptr ) {
-        elogger->critical("Failed to create producer with error: {}.", error_string );
+        logger->critical("Failed to create producer with error: " + error_string);
         return false;
     }
 
     published_topic_ptr = std::shared_ptr<RdKafka::Topic>( RdKafka::Topic::create(producer_ptr.get(), published_topic_name, tconf, error_string) );
     if ( !published_topic_ptr ) {
-        elogger->critical("Failed to create topic: {}. Error: {}.", published_topic_name, error_string );
+        logger->critical("Failed to create topic: " + published_topic_name + ". Error: " + error_string + ".");
         return false;
     } 
 
-    ilogger->info("Producer: {} created using topic: {}.", producer_ptr->name(), published_topic_name);
+    logger->info("Producer: " + producer_ptr->name() + " created using topic: " + published_topic_name + ".");
     return true;
 }
 
@@ -595,7 +594,7 @@ bool ASN1_Codec::launch_consumer(){
     if(!consumer_ptr){
         consumer_ptr = std::shared_ptr<RdKafka::KafkaConsumer>( RdKafka::KafkaConsumer::create(conf, error_string) );
         if (!consumer_ptr) {
-            elogger->critical("Failed to create consumer with error: {}",  error_string );
+            logger->critical("Failed to create consumer with error: " + error_string);
             return false;
         }
     }
@@ -606,14 +605,14 @@ bool ASN1_Codec::launch_consumer(){
     for ( auto& topic : consumed_topics ) {
         while ( data_available && tcount < consumed_topics.size() ) {
             if ( topic_available(topic) ) {
-                ilogger->trace("Consumer topic: {} is available.", topic);
+                logger->trace("Consumer topic: " + topic + " is available.");
                 // count it and attempt to get the next one if it exists.
                 ++tcount;
                 break;
             }
             // topic is not available, wait for a second or two.
             std::this_thread::sleep_for( std::chrono::milliseconds( 1500 ) );
-            ilogger->trace("Waiting for needed consumer topic: {}.", topic);
+            logger->trace("Waiting for needed consumer topic: " + topic + ".");
         }
     }
 
@@ -621,11 +620,11 @@ bool ASN1_Codec::launch_consumer(){
         // all the needed topics are available for subscription.
         RdKafka::ErrorCode status = consumer_ptr->subscribe(consumed_topics);
         if (status) {
-            elogger->critical("Failed to subscribe to {} topics. Error: {}.", consumed_topics.size(), RdKafka::err2str(status) );
+            logger->critical("Failed to subscribe to " + std::to_string(consumed_topics.size()) + " topics. Error: " + RdKafka::err2str(status) + ".");
             return false;
         }
     } else {
-        ilogger->warn("User cancelled ASN1_Codec while waiting for topics to become available.");
+        logger->warn("User cancelled ASN1_Codec while waiting for topics to become available.");
         return false;
     }
 
@@ -635,7 +634,7 @@ bool ASN1_Codec::launch_consumer(){
         osbuf << topic;
     }
 
-    ilogger->info("Consumer: {} created using topics: {}.", consumer_ptr->name(), osbuf.str());
+    logger->info("Consumer: " + consumer_ptr->name() + " created using topics: " + osbuf.str() + ".");
     return true;
 }
 
@@ -696,15 +695,8 @@ bool ASN1_Codec::make_loggers( bool remove_files ) {
         }
     }
 
-    // setup information logger.
-    ilogger = spdlog::rotating_logger_mt("ilog", ilogname, ilogsize, ilognum);
-    ilogger->set_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
-    ilogger->set_level( iloglevel );
-
-    // setup error logger.
-    elogger = spdlog::rotating_logger_mt("elog", elogname, elogsize, elognum);
-    elogger->set_level( iloglevel );
-    elogger->set_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
+    // initialize logger
+    logger = std::make_shared<AcmLogger>(ilogname, elogname);
     return true;
 }
 
@@ -754,7 +746,7 @@ bool ASN1_Codec::make_loggers( bool remove_files ) {
      */
 
 bool ASN1_Codec::add_error_xml( pugi::xml_document& doc, Asn1DataType dt, Asn1ErrorType et, std::string message, bool update_time ) {
-	static const char* fnname = "add_error_xml()";
+	const std::string fnname = "add_error_xml()";
 	bool r = true;
 
 	// Attempt to set all these fields; log the errors; return false if any fail.
@@ -762,35 +754,35 @@ bool ASN1_Codec::add_error_xml( pugi::xml_document& doc, Asn1DataType dt, Asn1Er
 	// access this directly because we remove the bytes branch.
 	pugi::xml_node metadata_node = doc.child("OdeAsn1Data").child("metadata");
 	if ( !metadata_node ) {
-		//elogger->error("{}: Cannot find OdeAsn1Data/metadata nodes in function input document.", fnname );
+		// logger->error(fnname + ": Cannot find OdeAsn1Data/metadata nodes in function input document.");
 		return false;
 	}
 
 	pugi::xml_node payload_node  = doc.child("OdeAsn1Data").child("payload");
 	if ( !payload_node ) {
-		//elogger->error("{}: Cannot find OdeAsn1Data/payload nodes in function input document.", fnname );
+		// logger->error(fnname + ": Cannot find OdeAsn1Data/payload nodes in function input document.");
 		return false;
 	}
 
 	if ( !metadata_node.child("payloadType").text().set( asn1datatypes[static_cast<int>(Asn1DataType::PAYLOAD)]  ) ) {
-		//elogger->error("{}: Failure to update the payloadType field of the error xml", fnname );
+		// logger->error(fnname + ": Failure to update the payloadType field of the error xml");
 		r = false;
 	}
 
 	// receivedAt is only updatable if update_time is true.
 	if ( update_time && !metadata_node.child("receivedAt").text().set( get_current_time().c_str() ) ) {
-		//elogger->error("{}: Failure to update the receivedAt field of the error xml", fnname );
+		// logger->error(fnname + ": Failure to update the receivedAt field of the error xml");
 		r = false;
 	}
 
 	// generateAt time is always updated; it is the time of generating this message.
 	if ( !metadata_node.child("generatedAt").text().set( get_current_time().c_str() ) ) {
-		//elogger->error("{}: Failure to update the generatedAt field of the error xml", fnname );
+		// logger->error(fnname + ": Failure to update the generatedAt field of the error xml");
 		r = false;
 	}
 
 	if ( !payload_node.child("dataType").text().set( asn1datatypes[static_cast<int>(dt)]  ) ) {
-		//elogger->error("{}: Failure to update the dataType field of the error xml", fnname );
+		// logger->error(fnname + ": Failure to update the dataType field of the error xml");
 		r = false;
 	}
 
@@ -808,12 +800,12 @@ bool ASN1_Codec::add_error_xml( pugi::xml_document& doc, Asn1DataType dt, Asn1Er
 	}
 
 	if ( !data_node.child("code").text().set( asn1errortypes[static_cast<int>(et)]  ) ) {
-		//elogger->error("{}: Failure to update the data/code field of the error xml", fnname );
+		// logger->error(fnname + ": Failure to update the data/code field of the error xml");
 		r = false;
 	}
 
 	if ( !data_node.child("message").text().set( message.c_str() ) ) {
-		//elogger->error("{}: Failure to update the data/message field of the error xml", fnname );
+		// logger->error(fnname + ": Failure to update the data/message field of the error xml");
 		r = false;
 	}
 
@@ -925,7 +917,7 @@ enum asn_transfer_syntax ASN1_Codec::get_ats_transfer_syntax( const char* ats ) 
 }
 
 bool ASN1_Codec::process_message(RdKafka::Message* message, std::stringstream& output_message_stream ) {
-    static const char* fnname = "process_message()";
+    const std::string fnname = "process_message()";
     static std::string tsname;
     static RdKafka::MessageTimestamp ts;
     
@@ -934,16 +926,16 @@ bool ASN1_Codec::process_message(RdKafka::Message* message, std::stringstream& o
 
     size_t bytes_processed = 0;
 
-	ilogger->trace("{}: starting...", fnname);
+	logger->trace(fnname + ": starting...");
 
     switch (message->err()) {
 
         case RdKafka::ERR__TIMED_OUT:
-            ilogger->info("{}: Waiting for more BSMs.", fnname );
+            logger->info(fnname + ": Waiting for more BSMs.");
             break;
 
         case RdKafka::ERR__MSG_TIMED_OUT:
-            ilogger->info("{}: Waiting for more BSMs from the ODE producer.", fnname );
+            logger->info(fnname + ": Waiting for more BSMs from the ODE producer.");
             break;
 
         case RdKafka::ERR_NO_ERROR:
@@ -951,7 +943,7 @@ bool ASN1_Codec::process_message(RdKafka::Message* message, std::stringstream& o
             msg_recv_count++;
             msg_recv_bytes += message->len();
 
-            ilogger->trace("{}: Read message at byte offset: {} with length {}", fnname , message->offset(), message->len() );
+            logger->trace(fnname + ": Read message at byte offset: " + std::to_string(message->offset()) + " with length " + std::to_string(message->len()));
 
             ts = message->timestamp();
 
@@ -964,11 +956,11 @@ bool ASN1_Codec::process_message(RdKafka::Message* message, std::stringstream& o
                     tsname = "unknown";
                 }
 
-                ilogger->trace("{}: Message timestamp: {}, type: {}", fnname , tsname, ts.timestamp);
+                logger->trace(fnname + ": Message timestamp: " + tsname + ", type: " + std::to_string(ts.timestamp));
             }
 
             if ( message->key() ) {
-                ilogger->trace("{}: Message key: {}", fnname , *message->key() );
+                logger->trace(fnname + ": Message key: " + *message->key() );
             }
 
             // already verified non-zero message length.
@@ -1001,42 +993,42 @@ bool ASN1_Codec::process_message(RdKafka::Message* message, std::stringstream& o
             break;
 
         case RdKafka::ERR__PARTITION_EOF:
-            ilogger->info("ODE BSM consumer partition end of file, but ASN1_Codec still alive.");
+            logger->info("ODE BSM consumer partition end of file, but ASN1_Codec still alive.");
             if (exit_eof) {
                 eof_cnt++;
 
                 if (eof_cnt == partition_cnt) {
-                    ilogger->info("EOF reached for all {} partition(s)", partition_cnt);
+                    logger->info("EOF reached for all " + std::to_string(partition_cnt) + " partition(s)");
                     data_available = false;
                 }
             }
             break;
 
         case RdKafka::ERR__UNKNOWN_TOPIC:
-            elogger->error("cannot consume due to an UNKNOWN consumer topic: {}", message->errstr());
+            logger->error("cannot consume due to an UNKNOWN consumer topic: " + message->errstr());
 
         case RdKafka::ERR__UNKNOWN_PARTITION:
-            elogger->error("cannot consume due to an UNKNOWN consumer partition: {}", message->errstr());
+            logger->error("cannot consume due to an UNKNOWN consumer partition: " + message->errstr());
             data_available = false;
             break;
 
         default:
-            elogger->error("cannot consume due to an error: {}", message->errstr());
+            logger->error("cannot consume due to an error: " + message->errstr());
             data_available = false;
     }
 
-	ilogger->trace("{}: finished...", fnname);
+	logger->trace(fnname + ": finished...");
     return false;
 }
 
 bool ASN1_Codec::decode_message( pugi::xml_node& payload_node, std::stringstream& output_message_stream ) {
-    static const char* fnname = "decode_message()";
+    const std::string fnname = "decode_message()";
     bool success = true;
     pugi::xml_parse_result parse_result;
 
     buffer_structure_t xb = {0, 0, 0};
 
-    ilogger->trace("{}: starting...", fnname);
+    logger->trace(fnname + ": starting...");
 
     if ( !decode_1609dot2 && !decode_messageframe ) {
         // if neither of these is set, this function becomes a noop and nothing will be returned, so this is an
@@ -1112,7 +1104,7 @@ bool ASN1_Codec::decode_message( pugi::xml_node& payload_node, std::stringstream
 
     // convert DOM to a RAW string representation: no spaces, no tabs.
     input_doc.save(output_message_stream,"",pugi::format_raw);
-    ilogger->trace("{}: finished...", fnname);
+    logger->trace(fnname + ": finished...");
     return success;
 } 
 
@@ -1182,7 +1174,7 @@ void ASN1_Codec::encode_for_protocol() {
 // throws MissingInputElementError or Asn1CodecError (from encode_messageframe_data call) ONLY!
 bool ASN1_Codec::encode_message( std::stringstream& output_message_stream ) {
 
-    static const char* fnname = "encode_message()";
+    const std::string fnname = "encode_message()";
 
     protocol_.clear();
     hex_data_.clear();
@@ -1249,7 +1241,7 @@ bool ASN1_Codec::encode_message( std::stringstream& output_message_stream ) {
 
 // throws Asn1CodecError ONLY!
 bool ASN1_Codec::decode_1609dot2_data( std::string& data_as_hex, buffer_structure_t* xml_buffer ) {
-    static const char* fnname = "decode_1609dot2_data()";
+    const std::string fnname = "decode_1609dot2_data()";
 
     // enum asn_dec_rval_code_e {
     // 	RC_OK,		                                  // successful decoding.
@@ -1275,7 +1267,7 @@ bool ASN1_Codec::decode_1609dot2_data( std::string& data_as_hex, buffer_structur
 
     Ieee1609Dot2Data_t *ieee1609data = 0;        // must initialize to 0 according to asn.1 instructions.
 
-    ilogger->trace("{}: starting...", fnname);
+    logger->trace(fnname + ": starting...");
 
     // remove all spaces.
     data_as_hex.erase( remove_if ( data_as_hex.begin(), data_as_hex.end(), isspace), data_as_hex.end());
@@ -1284,14 +1276,14 @@ bool ASN1_Codec::decode_1609dot2_data( std::string& data_as_hex, buffer_structur
         throw Asn1CodecError{"failed attempt to decode IEEE 1609.2 hex string: string empty."};
     }
 
-    ilogger->trace("{}: success extracting {} hex string: {}", fnname , asn_DEF_Ieee1609Dot2Data.name, data_as_hex );
+    logger->trace(fnname + ": success extracting " + asn_DEF_Ieee1609Dot2Data.name + " hex string: " + data_as_hex );
 
     byte_buffer.clear();
     if (!hex_to_bytes_(data_as_hex, byte_buffer)) {
         throw Asn1CodecError{"failed attempt to decode IEEE 1609.2 hex string: cannot convert to bytes."};
     }
 
-    ilogger->trace("{}: successful conversion to raw byte buffer.", fnname );
+    logger->trace(fnname + ": successful conversion to raw byte buffer." );
 
     // Decode BAH Bytes (A 1609.2 Frame) into the appropriate structure.
     decode_rval = asn_decode( 
@@ -1315,7 +1307,7 @@ bool ASN1_Codec::decode_1609dot2_data( std::string& data_as_hex, buffer_structur
         throw Asn1CodecError{ erroross.str() };
     }
 
-    ilogger->trace("{}: ASN.1 binary decode success.", fnname );
+    logger->trace(fnname + ": ASN.1 binary decode success." );
 
     // check the data in the returned structure against the ASN.1 specification constraints.
     if (asn_check_constraints( &asn_DEF_Ieee1609Dot2Data, ieee1609data, errbuf, &errlen )) {
@@ -1343,7 +1335,7 @@ bool ASN1_Codec::decode_1609dot2_data( std::string& data_as_hex, buffer_structur
         throw Asn1CodecError{ erroross.str() };
     }
 
-    ilogger->trace("{}: finished.", fnname );
+    logger->trace(fnname + ": finished.");
     return true;
 }
 
@@ -1351,7 +1343,7 @@ bool ASN1_Codec::decode_1609dot2_data( std::string& data_as_hex, buffer_structur
  * TODO: This method should be generalizable to any type def and structure pointer -- tried but moved on.
  */
 bool ASN1_Codec::decode_messageframe_data( std::string& data_as_hex, buffer_structure_t* xml_buffer ) {
-    static const char* fnname = "decode_messageframe_data()";
+    const std::string fnname = "decode_messageframe_data()";
 
     asn_dec_rval_t decode_rval;
     asn_enc_rval_t encode_rval;
@@ -1360,7 +1352,7 @@ bool ASN1_Codec::decode_messageframe_data( std::string& data_as_hex, buffer_stru
 
     MessageFrame_t *messageframe = 0;           // must be initialized to 0.
 
-    ilogger->trace("{}: starting...", fnname);
+    logger->trace(fnname + ": starting...");
 
     // remove all spaces.
     data_as_hex.erase( remove_if ( data_as_hex.begin(), data_as_hex.end(), isspace), data_as_hex.end());
@@ -1369,14 +1361,14 @@ bool ASN1_Codec::decode_messageframe_data( std::string& data_as_hex, buffer_stru
         throw Asn1CodecError{"failed attempt to decode MessageFrame hex string: string empty."};
     }
 
-    ilogger->trace("{}: success extracting {} hex string: {}", fnname , asn_DEF_MessageFrame.name, data_as_hex );
+    logger->trace(fnname + ": success extracting " + asn_DEF_MessageFrame.name + " hex string: " + data_as_hex);
 
     byte_buffer.clear();
     if (!hex_to_bytes_(data_as_hex, byte_buffer)) {
         throw Asn1CodecError{"failed attempt to decode MessageFrame hex string: cannot convert to bytes."};
     }
 
-    ilogger->trace("{}: successful conversion to raw byte buffer.", fnname );
+    logger->trace(fnname + ": successful conversion to raw byte buffer.");
 
     decode_rval = asn_decode( 
             0, 
@@ -1399,7 +1391,7 @@ bool ASN1_Codec::decode_messageframe_data( std::string& data_as_hex, buffer_stru
         throw Asn1CodecError{ erroross.str() };
     }
 
-    ilogger->trace("{}: ASN.1 binary decode successful.", fnname );
+    logger->trace(fnname + ": ASN.1 binary decode successful.");
 
     if (asn_check_constraints( &asn_DEF_MessageFrame, messageframe, errbuf, &errlen )) {
         erroross.str("");
@@ -1426,12 +1418,12 @@ bool ASN1_Codec::decode_messageframe_data( std::string& data_as_hex, buffer_stru
         throw Asn1CodecError{ erroross.str() };
     }
 
-    ilogger->trace("{}: finished.", fnname );
+    logger->trace(fnname + ": finished.");
     return true;
 }
         
 void ASN1_Codec::encode_frame_data(const std::string& data_as_xml, std::string& hex_string) {
-    static const char* fnname = "encode_frame_data()";
+    const std::string fnname = "encode_frame_data()";
 
     asn_dec_rval_t decode_rval;
     asn_enc_rval_t encode_rval;
@@ -1517,7 +1509,7 @@ void ASN1_Codec::encode_frame_data(const std::string& data_as_xml, std::string& 
 }
 
 bool ASN1_Codec::set_codec_requirements( pugi::xml_document& doc ) {
-    static const char* fnname = "set_codec_requirements()";
+    const std::string fnname = "set_codec_requirements()";
 
     enum asn_transfer_syntax atstype = ATS_INVALID;
 	opsflag = 0;
@@ -1576,7 +1568,7 @@ bool ASN1_Codec::set_codec_requirements( pugi::xml_document& doc ) {
 }
 
 bool ASN1_Codec::file_test(std::string file_path, std::ostream& os, bool encode) {
-    static const char* fnname = "file_test()";
+    const std::string fnname = "file_test()";
 
     std::stringstream output_msg_stream;
     bool r = true;
@@ -1633,28 +1625,28 @@ bool ASN1_Codec::file_test(std::string file_path, std::ostream& os, bool encode)
         } catch (const UnparseableInputError& e) {
 
             r = false;
-            //elogger->trace("{}: UnparseableInputError {}", fnname , e.what() );
+            // logger->trace(fnname + ": UnparseableInputError " + e.what());
             add_error_xml( error_doc, e.data_type(), e.error_type(), e.what(), true );
             error_doc.save(output_msg_stream,"",pugi::format_raw);
 
         } catch (const MissingInputElementError& e) {
 
             r = false;
-            //elogger->trace("{}: MissingInputElementError {}", fnname , e.what() );
+            // logger->trace(fnname + ": MissingInputElementError " + e.what() );
             add_error_xml( error_doc, e.data_type(), e.error_type(), e.what(), true );
             error_doc.save(output_msg_stream,"",pugi::format_raw);
 
         } catch (const pugi::xpath_exception& e ) {
 
             r = false;
-            //elogger->trace("{}: pugi::xpath_exception {}", fnname, e.what() );
+            // logger->trace(fnname + ": pugi::xpath_exception " + e.what() );
             add_error_xml( error_doc, Asn1DataType::ODE, Asn1ErrorType::REQUEST, e.what(), true );
             error_doc.save(output_msg_stream,"",pugi::format_raw);
 
         } catch (const Asn1CodecError& e) {
 
             r = false;
-            //elogger->trace("{}: Asn1CodecError {}", fnname , e.what() );
+            // logger->trace(fnname + ": Asn1CodecError " + e.what() );
             add_error_xml( input_doc, e.data_type(), e.error_type(), e.what(), false );
             input_doc.save(output_msg_stream,"",pugi::format_raw);
         }
@@ -1670,7 +1662,7 @@ bool ASN1_Codec::file_test(std::string file_path, std::ostream& os, bool encode)
  *
  */
 bool ASN1_Codec::filetest() {
-    static const char* fnname = "filetest()";
+    const std::string fnname = "filetest()";
     bool r = true;
 
     std::string error_string;
@@ -1690,7 +1682,7 @@ bool ASN1_Codec::filetest() {
         return EXIT_FAILURE;
     }
 
-    ilogger->trace("{}: Starting...", fnname);
+    logger->trace(fnname + ": Starting...");
 
     std::FILE* ifile = std::fopen( operands[0].c_str(), "r" );
     if (!ifile) {
@@ -1709,7 +1701,7 @@ bool ASN1_Codec::filetest() {
 
     if ( consumed_xml_buffer.size() > 0 ) {
 
-        ilogger->trace("{}: successful read of the test file having {} bytes.", fnname, consumed_xml_buffer.size() );
+        logger->trace(fnname + ": successful read of the test file having " + std::to_string(consumed_xml_buffer.size()) + " bytes.");
 
         msg_recv_count++;
         msg_recv_bytes += consumed_xml_buffer.size();
@@ -1744,28 +1736,28 @@ bool ASN1_Codec::filetest() {
         } catch (const UnparseableInputError& e) {
 
             r = false;
-            elogger->trace("{}: UnparseableInputError {}", fnname , e.what() );
+            logger->trace(fnname + ": UnparseableInputError " + std::string(e.what()));
             add_error_xml( error_doc, e.data_type(), e.error_type(), e.what(), true );
             error_doc.save(output_msg_stream,"",pugi::format_raw);
 
         } catch (const MissingInputElementError& e) {
 
             r = false;
-            elogger->trace("{}: MissingInputElementError {}", fnname , e.what() );
+            logger->trace(fnname + ": MissingInputElementError " + std::string(e.what()));
             add_error_xml( error_doc, e.data_type(), e.error_type(), e.what(), true );
             error_doc.save(output_msg_stream,"",pugi::format_raw);
 
         } catch (const pugi::xpath_exception& e ) {
 
             r = false;
-            elogger->trace("{}: pugi::xpath_exception {}", fnname, e.what() );
+            logger->trace(fnname + ": pugi::xpath_exception " + std::string(e.what()));
             add_error_xml( error_doc, Asn1DataType::ODE, Asn1ErrorType::REQUEST, e.what(), true );
             error_doc.save(output_msg_stream,"",pugi::format_raw);
 
         } catch (const Asn1CodecError& e) {
 
             r = false;
-            elogger->trace("{}: Asn1CodecError {}", fnname , e.what() );
+            logger->trace(fnname + ": Asn1CodecError " + std::string(e.what()));
             add_error_xml( input_doc, e.data_type(), e.error_type(), e.what(), false );
             input_doc.save(output_msg_stream,"",pugi::format_raw);
 
@@ -1774,19 +1766,18 @@ bool ASN1_Codec::filetest() {
         std::cout << output_msg_stream.str() << '\n';
 
     } else {
-        ilogger->trace("Read an empty file.");
+        logger->trace("Read an empty file.");
     }
 
     // NOTE: good for troubleshooting, but bad for performance.
-    ilogger->trace("{}: Finished.", fnname);
-    elogger->flush();
-    ilogger->flush();
+    logger->trace(fnname + ": Finished.");
+    logger->flush();
 
     return r ? EXIT_SUCCESS : EXIT_FAILURE;
 }
 
 int ASN1_Codec::operator()(void) {
-    static const char* fnname = "run()";
+    const std::string fnname = "run()";
 
     RdKafka::ErrorCode status;
     std::string error_string;
@@ -1836,25 +1827,25 @@ int ASN1_Codec::operator()(void) {
 
             } catch (const UnparseableInputError& e) {
 
-                elogger->trace("{}: UnparseableInputError {}", fnname , e.what() );
+                logger->trace(fnname + ": UnparseableInputError " + e.what() );
                 add_error_xml( error_doc, e.data_type(), e.error_type(), e.what(), true );
                 error_doc.save(output_msg_stream,"",pugi::format_raw);
 
             } catch (const MissingInputElementError& e) {
 
-                elogger->trace("{}: MissingInputElementError {}", fnname , e.what() );
+                logger->trace(fnname + ": MissingInputElementError " + e.what() );
                 add_error_xml( error_doc, e.data_type(), e.error_type(), e.what(), true );
                 error_doc.save(output_msg_stream,"",pugi::format_raw);
 
             } catch (const pugi::xpath_exception& e ) {
 
-                elogger->trace("{}: pugi::xpath_exception {}", fnname, e.what() );
+                logger->trace(fnname + ": pugi::xpath_exception " + e.what() );
                 add_error_xml( error_doc, Asn1DataType::ODE, Asn1ErrorType::REQUEST, e.what(), true );
                 error_doc.save(output_msg_stream,"",pugi::format_raw);
 
             } catch (const Asn1CodecError& e) {
 
-                elogger->trace("{}: Asn1CodecError {}", fnname , e.what() );
+                logger->trace(fnname + ": Asn1CodecError " + e.what());
                 add_error_xml( input_doc, e.data_type(), e.error_type(), e.what(), false );
                 input_doc.save(output_msg_stream,"",pugi::format_raw);
 
@@ -1868,13 +1859,13 @@ int ASN1_Codec::operator()(void) {
                 status = producer_ptr->produce(published_topic_ptr.get(), partition, RdKafka::Producer::RK_MSG_COPY, (void *)output_msg_string.c_str(), output_msg_string.size(), NULL, NULL);
 
                 if (status != RdKafka::ERR_NO_ERROR) {
-                    elogger->error("{}: Failure of XER encoding: {}", fnname , RdKafka::err2str( status ));
+                    logger->error(fnname + ": Failure of XER encoding: " + RdKafka::err2str(status));
 
                 } else {
                     // successfully sent; update counters.
                     msg_send_count++;
                     msg_send_bytes += output_msg_string.size();
-                    ilogger->trace("{}: successful encoding/decoding", fnname );
+                    logger->trace(fnname + ": successful encoding/decoding");
                     std::cerr << output_msg_string.size() << " bytes produced to topic: " << published_topic_ptr->name() << '\n';
                 }
 
@@ -1884,17 +1875,16 @@ int ASN1_Codec::operator()(void) {
             } 
 
             // NOTE: good for troubleshooting, but bad for performance.
-            elogger->flush();
-            ilogger->flush();
+            logger->flush();
         }
     }
 
-    ilogger->info("{}: shutting down...", fnname );
-    ilogger->info("ASN1_Codec consumed  : {} blocks and {} bytes", msg_recv_count, msg_recv_bytes);
-    ilogger->info("ASN1_Codec published : {} blocks and {} bytes", msg_send_count, msg_send_bytes);
+    logger->info(fnname + ": shutting down..." );
+    logger->info("ASN1_Codec consumed  : " + std::to_string(msg_recv_count) + " blocks and " + std::to_string(msg_recv_bytes) + " bytes");
+    logger->info("ASN1_Codec published : " + std::to_string(msg_send_count) + " blocks and " + std::to_string(msg_send_bytes) + " bytes");
 
     std::cerr << "ASN1_Codec operations complete; shutting down...\n";
-    std::cerr << "ASN1_Codec consumed   : " << msg_recv_count << " blocks and " << msg_recv_bytes << " bytes\n";
+    std::cerr << "ASN1_Codec consumed   : " << std::to_string(msg_recv_count) << " blocks and " << std::to_string(msg_recv_bytes) << " bytes\n";
     std::cerr << "ASN1_Codec published  : " << msg_send_count << " blocks and " << msg_send_bytes << " bytes\n";
     return EXIT_SUCCESS;
 }
@@ -1902,7 +1892,7 @@ int ASN1_Codec::operator()(void) {
 const char* ASN1_Codec::getEnvironmentVariable(const char* variableName) {
     const char* toReturn = std::getenv(variableName);
     if (!toReturn) {
-        ilogger->error("Something went wrong attempting to retrieve the environment variable {}", variableName);
+        logger->error("Something went wrong attempting to retrieve the environment variable " + std::string(variableName));
         toReturn = "";
     }
     return toReturn;
@@ -1959,12 +1949,12 @@ int main( int argc, char* argv[] )
                 std::exit( EXIT_SUCCESS );
             } else {
                 std::cerr << "Current configuration settings do not work.\n";
-                asn1_codec.ilogger->error( "current configuration settings do not work; exiting." );
+                asn1_codec.logger->error( "current configuration settings do not work; exiting." );
                 std::exit( EXIT_FAILURE );
             }
         } catch ( std::exception& e ) {
             std::cerr << "Fatal Exception: " << e.what() << '\n';
-            asn1_codec.elogger->error( "exception: {}", e.what() );
+            asn1_codec.logger->error("exception: " + std::string(e.what()));
             std::exit( EXIT_FAILURE );
         }
     }

--- a/src/acmLogger.cpp
+++ b/src/acmLogger.cpp
@@ -1,0 +1,117 @@
+#include "../include/acmLogger.hpp"
+
+AcmLogger::AcmLogger(std::string ilogname, std::string elogname) {
+    // pull in the file & console flags from the environment
+    initializeFlagValuesFromEnvironment();
+    
+    // setup information logger.
+    std::vector<spdlog::sink_ptr> infoSinks;
+    if (logToFileFlag) {
+        infoSinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(ilogname, INFO_LOG_SIZE, INFO_LOG_NUM));
+    }
+    if (logToConsoleFlag) {
+        infoSinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
+    }
+    setInfoLogger(std::make_shared<spdlog::logger>("ilog", begin(infoSinks), end(infoSinks)));
+    set_info_level( iloglevel );
+    set_info_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
+
+    // setup error logger.
+    std::vector<spdlog::sink_ptr> errorSinks;
+    if (logToFileFlag) {
+        errorSinks.push_back(std::make_shared<spdlog::sinks::rotating_file_sink_mt>(elogname, ERROR_LOG_SIZE, ERROR_LOG_NUM));
+    }
+    if (logToConsoleFlag) {
+        errorSinks.push_back(std::make_shared<spdlog::sinks::stdout_sink_mt>());
+    }
+    setErrorLogger(std::make_shared<spdlog::logger>("elog", begin(errorSinks), end(errorSinks)));
+    set_error_level( eloglevel );
+    set_error_pattern("[%C%m%d %H:%M:%S.%f] [%l] %v");
+}
+
+void AcmLogger::set_info_level(spdlog::level::level_enum level) {
+    ilogger->set_level( level );
+}
+
+void AcmLogger::set_error_level(spdlog::level::level_enum level) {
+    elogger->set_level( level );
+}
+
+void AcmLogger::set_info_pattern(const std::string& pattern) {
+    ilogger->set_pattern( pattern );
+}
+
+void AcmLogger::set_error_pattern(const std::string& pattern) {
+    elogger->set_pattern( pattern );
+}
+
+void AcmLogger::info(const std::string& message) {
+    ilogger->info(message.c_str());
+}
+
+void AcmLogger::error(const std::string& message) {
+    elogger->error(message.c_str());
+}
+
+void AcmLogger::trace(const std::string& message) {
+    ilogger->trace(message.c_str());
+}
+
+void AcmLogger::critical(const std::string& message) {
+    elogger->critical(message.c_str());
+}
+
+void AcmLogger::warn(const std::string& message) {
+    elogger->warn(message.c_str());
+}
+
+void AcmLogger::flush() {
+    ilogger->flush();
+    elogger->flush();
+}
+
+void AcmLogger::setInfoLogger(std::shared_ptr<spdlog::logger> spdlog_logger) {
+    ilogger = spdlog_logger;
+}
+
+void AcmLogger::setErrorLogger(std::shared_ptr<spdlog::logger> spdlog_logger) {
+    elogger = spdlog_logger;
+}
+
+void AcmLogger::initializeFlagValuesFromEnvironment() {
+    std::string logToFileFlagString = getEnvironmentVariable("ACM_LOG_TO_FILE");
+    std::string logToConsoleFlagString = getEnvironmentVariable("ACM_LOG_TO_CONSOLE");
+    logToFileFlag = convertStringToBool(logToFileFlagString);
+    logToConsoleFlag = convertStringToBool(logToConsoleFlagString);
+
+    if (!logToFileFlag && !logToConsoleFlag) {
+        std::cout << "WARNING: ACM_LOG_TO_FILE and ACM_LOG_TO_CONSOLE are both set to false. No logging will occur." << std::endl;
+    }
+}
+
+const char* AcmLogger::getEnvironmentVariable(std::string variableName) {
+    char* variableValue = getenv(variableName.c_str());
+    if (variableValue == NULL) {
+        return "";
+    }
+    return variableValue;
+}
+
+std::string AcmLogger::toLowercase(std::string s) {
+    int counter = 0;
+    char c;
+    while (s[counter]) {
+        c = s[counter];
+        s[counter] = tolower(c);
+        counter++;
+    }
+    return s;
+}
+
+bool AcmLogger::convertStringToBool(std::string value) {
+    std::string lowercaseValue = toLowercase(value);
+    if (lowercaseValue == "true" || lowercaseValue == "1") {
+        return true;
+    }
+    return false;
+}


### PR DESCRIPTION
## Purpose
The changes in this PR are intended to simplify and expand the logging capabilities of the ACM.

## Notes
- The 'AcmLogger' class has been introduced to the project which is intended to serve as an abstraction layer between the ACM and the spdlog library. 
- The details of the setup and usage of spdlog is no longer of concern to the asn1_codec class and has been delegated to the AcmLogger class.
- All statements previously using spdlog now use a single logger instance instead.
- The 'ACM_LOG_TO_FILE' and 'ACM_LOG_TO_CONSOLE' environment variables have been introduced to the project. These are optional and if both are unset or set to false, a message will be printed to the console to warn the user that no logging will occur.