### PR TITLE
Memory Leak Fix - Freed Metadata Pointer

### DIFF
--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -293,7 +293,7 @@ void ASN1_Codec::metadata_print (const std::string &topic, const RdKafka::Metada
 bool ASN1_Codec::topic_available( const std::string& topic ) {
     bool r = false;
 
-    RdKafka::Metadata* md;
+    RdKafka::Metadata* md; // must be freed if allocated
     RdKafka::ErrorCode err = consumer_ptr->metadata( true, nullptr, &md, 5000 );
     // TODO: Will throw a broker transport error (ERR__TRANSPORT = -195) if the broker is not available.
 
@@ -315,6 +315,10 @@ bool ASN1_Codec::topic_available( const std::string& topic ) {
 
     } else {
         elogger->error( "cannot retrieve consumer metadata with error: {}.", err2str(err) );
+    }
+
+    if (md) {
+        delete md; // free metadata
     }
 
     return r;


### PR DESCRIPTION
## The Problem
The metadata pointer in the ASN1_Codec::topic_available() method was not being freed, resulting in a memory leak of 27,532,452 bytes (~27.5mb) per hour.

## Changes
The following code was added to the method (lines 320-322) to resolve this:
```
    if (md) {
        delete md; // free metadata
    }
```

A comment was also added at the creation of the pointer on line 296 informing the developer that it must be freed if allocated:
```
    RdKafka::Metadata* md; // must be freed if allocated
```

## Valgrind Results
The ACM was run with [valgrind](https://valgrind.org/)'s memory error detector for 10 minutes before and after the fix was applied.

**Before:**
```
==255== LEAK SUMMARY:
==255==    definitely lost: 41,664 bytes in 434 blocks
==255==    indirectly lost: 4,547,078 bytes in 72,477 blocks
==255==      possibly lost: 7,360 bytes in 5 blocks
==255==    still reachable: 226,535 bytes in 1,006 blocks
==255==         suppressed: 0 bytes in 0 blocks
```

**After:**
```
==254== LEAK SUMMARY:
==254==    definitely lost: 0 bytes in 0 blocks
==254==    indirectly lost: 0 bytes in 0 blocks
==254==      possibly lost: 1,344 bytes in 4 blocks
==254==    still reachable: 226,535 bytes in 1,006 blocks
==254==         suppressed: 0 bytes in 0 blocks
```

### Possibly Lost
#### Resolved
It would appear that a potential leak of 36,096 bytes (~36kb) per hour was also resolved.

#### Remaining
It should be noted that 8,004 bytes (~8kb) are still possibly lost per hour. A separate work item should be created to verify and resolve this potential leak.

### Still Reachable
According to the best answer to [this stack overflow post](https://stackoverflow.com/questions/3840582/still-reachable-leak-detected-by-valgrind), there's generally no need to worry about still reachable blocks.

## Dev Cluster Testing
The ACM has been verified to be working with these changes in our dev cluster.