### PR TITLE
Added check for build folder existence before deletion

### DIFF
--- a/build_local.sh
+++ b/build_local.sh
@@ -57,7 +57,10 @@ compileSpecAndBuildLibrary(){
 buildACM(){
     # Build the ACM
     echo "${GREEN}Building ACM${NC}"
-    rm -r build
+    if [ -d "./build" ]; then
+        echo "${INFO} Removing build directory"
+        rm -r build
+    fi
     mkdir build
     cd build
     cmake ..


### PR DESCRIPTION
We are now checking if the build folder exists before deleting it in the `build_local.sh` script.

This addresses the following comment:
https://github.com/usdot-jpo-ode/asn1_codec/pull/28#discussion_r1244160138