### PR TITLE
Removed deprecation warnings for files in `kafka-test` directory.

### DIFF
--- a/kafka-test/CMakeLists.txt
+++ b/kafka-test/CMakeLists.txt
@@ -33,8 +33,6 @@
 #      Laboratory
 #      865-804-5161 (mobile)
 
-# NOTE: THIS FILE IS DEPRECATED AS OF 5/17/2023 AND IS NOT RECOMMENDED FOR USE.
-
 cmake_minimum_required(VERSION 2.6)
 project(CVDIGeofenceTest)
 

--- a/kafka-test/src/rdkafka_example.cpp
+++ b/kafka-test/src/rdkafka_example.cpp
@@ -32,8 +32,6 @@
  * (https://github.com/edenhill/librdkafka)
  */
 
-// NOTE: THIS FILE IS DEPRECATED AS OF 5/17/2023 AND IS NOT RECOMMENDED FOR USE.
-
 #include <iostream>
 #include <string>
 #include <cstdlib>


### PR DESCRIPTION
The deprecation warnings that were recently added to the files in the `kafka-test` directory have been removed since it was found that there are references to them.