### PR TITLE
Strip unwanted headers from Ieee1609Dot2 data frames

### DIFF
--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -1444,6 +1444,8 @@ void ASN1_Codec::encode_frame_data(const std::string& data_as_xml, std::string& 
 	struct asn_TYPE_descriptor_s* data_struct;
     void *frame_data = 0;
 
+    // std::cout << "[DEBUG] Data as XML: " << data_as_xml << std::endl;
+
     switch (curr_op_) {
         case J2735MESSAGEFRAME:
             data_struct = &asn_DEF_MessageFrame;
@@ -1469,6 +1471,7 @@ void ASN1_Codec::encode_frame_data(const std::string& data_as_xml, std::string& 
 
     errlen = max_errbuf_size;
 
+    logger->trace(fnname + ": Data struct name: " + data_struct->name);
     decode_rval = xer_decode( 
             0 				// new parameter addition seems to work with nullptr.
 			, data_struct
@@ -1519,6 +1522,19 @@ void ASN1_Codec::encode_frame_data(const std::string& data_as_xml, std::string& 
     if (!bytes_to_hex_(&buffer, hex_string)) {
         std::free( static_cast<void *>(buffer.buffer) );
         throw Asn1CodecError{ "failed attempt to encode SDWTIM byte buffer into hex string." };
+    }
+    logger->trace(fnname + ": Encoded hex string: " + hex_string);
+    
+    // if data type is Ieee1609Dot2, check for hex before 001F and remove it if found
+    if (curr_op_ == IEEE1609DOT2) {
+        std::size_t pos = hex_string.find("001F");
+        if (pos != std::string::npos) {
+            logger->warn(fnname + ": Encoded hex string contains an unwanted header before 001F. Removing hex before 001F.");
+
+            // remove hex before 001F
+            hex_string = hex_string.substr(pos);
+            logger->trace(fnname + ": Encoded hex string after removing hex before 001F: " + hex_string);
+        }
     }
 
     std::free( static_cast<void *>(buffer.buffer) );

--- a/src/acm.cpp
+++ b/src/acm.cpp
@@ -1444,8 +1444,6 @@ void ASN1_Codec::encode_frame_data(const std::string& data_as_xml, std::string& 
 	struct asn_TYPE_descriptor_s* data_struct;
     void *frame_data = 0;
 
-    // std::cout << "[DEBUG] Data as XML: " << data_as_xml << std::endl;
-
     switch (curr_op_) {
         case J2735MESSAGEFRAME:
             data_struct = &asn_DEF_MessageFrame;
@@ -1523,17 +1521,15 @@ void ASN1_Codec::encode_frame_data(const std::string& data_as_xml, std::string& 
         std::free( static_cast<void *>(buffer.buffer) );
         throw Asn1CodecError{ "failed attempt to encode SDWTIM byte buffer into hex string." };
     }
-    logger->trace(fnname + ": Encoded hex string: " + hex_string);
     
     // if data type is Ieee1609Dot2, check for hex before 001F and remove it if found
     if (curr_op_ == IEEE1609DOT2) {
         std::size_t pos = hex_string.find("001F");
         if (pos != std::string::npos) {
-            logger->warn(fnname + ": Encoded hex string contains an unwanted header before 001F. Removing hex before 001F.");
+            logger->trace(fnname + ": Encoded hex string contains an unwanted header. Removing hex before 001F.");
 
             // remove hex before 001F
             hex_string = hex_string.substr(pos);
-            logger->trace(fnname + ": Encoded hex string after removing hex before 001F: " + hex_string);
         }
     }
 


### PR DESCRIPTION
## Problem
The SCMS files for this project were recently updated and headers started being added to messages during the encoding process for ASD payloads, even with unsigned TIMs. This causes problems when OBUs attempt to process the message.

## Solution
Any hex before '001F' that is found in an encoded Ieee1609Dot2 data frame is now stripped.

## Testing
- The unit tests have been verified to pass with these changes.
- This was tested locally using docker compose. ASD payloads, when decoded, were found to no longer include the header.
- This has been deployed to CDOT's dev environment. Deposits made to the SDX, when retrieved via the `GetDataByRecordId` endpoint, were found to no longer include the header.
- It should be noted that this has only been tested with signing disabled. We may want to perform further testing in an environment with signing enabled.