### PR TITLE
Added encoder topics to KAFKA_CREATE_TOPICS

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ services:
     environment:
       KAFKA_ADVERTISED_HOST_NAME: ${DOCKER_HOST_IP}
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_CREATE_TOPICS: "j2735asn1xer:1:1,j2735asn1per:1:1,topic.Asn1DecoderInput:1:1, topic.Asn1DecoderOutput:1:1"
+      KAFKA_CREATE_TOPICS: "j2735asn1xer:1:1,j2735asn1per:1:1,topic.Asn1DecoderInput:1:1,topic.Asn1DecoderOutput:1:1,topic.Asn1EncoderInput:1:1,topic.Asn1EncoderOutput:1:1"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
   asn1_codec:


### PR DESCRIPTION
## Problem
The KAFKA_CREATE_TOPICS environment variable specified for the 'kafka' service in the `docker-compose.yml` file does not include the input/output topics for the encoder configuration of the program. This means that developers have to manually modify the value of this environment variable in the docker-compose.yml when conducting standalone testing.

## Solution
The KAFKA_CREATE_TOPICS environment variable now references all four relevant kafka topics to the program:
- topic.Asn1DecoderInput
- topic.Asn1DecoderOutput
- topic.Asn1EncoderInput
- topic.Asn1EncoderOutput

## Testing
This has been tested locally by running `docker compose up --build` with the ACM in encoder mode and the program was able to find the required topics.