### PR TITLE
Compression

### DIFF
--- a/config/adm.properties
+++ b/config/adm.properties
@@ -26,8 +26,8 @@ max.partition.fetch.bytes=20971520
 # The host ip address for the Broker.
 # metadata.broker.list=localhost:9092
 
-# specify the compression codec for all data generated: none, gzip, snappy, lz4
-compression.type=none
+# specify the compression codec for all data generated: none, gzip, snappy, lz4, zstd
+compression.type=zstd
 
 # after offset reset, start consuming from the earliest offset
 auto.offset.reset=smallest

--- a/config/aem.properties
+++ b/config/aem.properties
@@ -26,8 +26,8 @@ max.partition.fetch.bytes=20971520
 # The host ip address for the Broker.
 # metadata.broker.list=localhost:9092
 
-# specify the compression codec for all data generated: none, gzip, snappy, lz4
-compression.type=none
+# specify the compression codec for all data generated: none, gzip, snappy, lz4, zstd
+compression.type=zstd
 
 # after offset reset, start consuming from the earliest offset
 auto.offset.reset=smallest


### PR DESCRIPTION
This PR switches the default adm.properties and aem.properties files to use zstd (ZStandard) compression by default. This change will help encourage new deployers to deploy the ODE with compression enabled which offers significant cost savings for bandwidth at a minimum cost of a small CPU increase. zstd was chosen based on experimental testing and comparison of the various available compression algorithms. During testing zstd showed a balance of exceptionally good compression, while minimizing additional required CPU load and latency.


This PR is one of multiple PR's on the ODE and its subcomponents to switch the full ODE system to use zstd compression. The corresponding PR to the ODE can be found here: https://github.com/CDOT-CV/jpo-ode/pull/111