### PR TITLE
Cleanup Dockerfiles by removing unused asn1c instructions and comments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,22 +58,8 @@ jobs:
 
       - name: Install pugixml
         run: |
-          git clone https://github.com/vlm/asn1c.git
           git clone https://github.com/zeux/pugixml.git
           cd ./pugixml && mkdir -p build && cd build && cmake .. && make && make install
-        working-directory: ${{ env.working-directory }}
-
-      - name: Build and install asn1c submodule
-        run: |
-          sudo apt-get -y install libtool autoconf
-          cd ./asn1c && aclocal && test -f configure || autoreconf -iv && ./configure && make && make install
-        working-directory: ${{ env.working-directory }}
-
-      - name: Generate ASN.1 API.
-        run: |
-          export LD_LIBRARY_PATH=/usr/local/lib
-          git clone https://github.com/usdot-jpo-ode/scms-asn1.git
-          cd ./asn1c_combined && bash doIt.sh
         working-directory: ${{ env.working-directory }}
 
       - name: Export environment variables

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
           apt update
           apt-get -y install sudo wget curl gnupg lsb-release gcovr unzip gcc-multilib libasan*
           sudo apt-get -y install software-properties-common
+          sudo apt-get -y install libcurl4-openssl-dev
           curl -fsSL https://download.docker.com/linux/ubuntu/gpg | sudo apt-key add -
           sudo add-apt-repository -y "deb [arch=amd64] https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable"
           sudo curl -L "https://github.com/docker/compose/releases/download/1.24.0/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,7 @@ jobs:
           cd ./pugixml && mkdir -p build && cd build && cmake .. && make && make install
         working-directory: ${{ env.working-directory }}
 
-      - name: Generate ASN.1 API.
+      - name: Extract implementation and header files
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib
           git clone https://github.com/usdot-jpo-ode/scms-asn1.git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,6 @@ jobs:
       - name: Extract implementation and header files
         run: |
           export LD_LIBRARY_PATH=/usr/local/lib
-          git clone https://github.com/usdot-jpo-ode/scms-asn1.git
           cd ./asn1c_combined && bash doIt.sh
         working-directory: ${{ env.working-directory }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,15 +58,8 @@ jobs:
 
       - name: Install pugixml
         run: |
-          git clone https://github.com/vlm/asn1c.git
           git clone https://github.com/zeux/pugixml.git
           cd ./pugixml && mkdir -p build && cd build && cmake .. && make && make install
-        working-directory: ${{ env.working-directory }}
-
-      - name: Build and install asn1c submodule
-        run: |
-          sudo apt-get -y install libtool autoconf
-          cd ./asn1c && aclocal && test -f configure || autoreconf -iv && ./configure && make && make install
         working-directory: ${{ env.working-directory }}
 
       - name: Generate ASN.1 API.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,8 +58,22 @@ jobs:
 
       - name: Install pugixml
         run: |
+          git clone https://github.com/vlm/asn1c.git
           git clone https://github.com/zeux/pugixml.git
           cd ./pugixml && mkdir -p build && cd build && cmake .. && make && make install
+        working-directory: ${{ env.working-directory }}
+
+      - name: Build and install asn1c submodule
+        run: |
+          sudo apt-get -y install libtool autoconf
+          cd ./asn1c && aclocal && test -f configure || autoreconf -iv && ./configure && make && make install
+        working-directory: ${{ env.working-directory }}
+
+      - name: Generate ASN.1 API.
+        run: |
+          export LD_LIBRARY_PATH=/usr/local/lib
+          git clone https://github.com/usdot-jpo-ode/scms-asn1.git
+          cd ./asn1c_combined && bash doIt.sh
         working-directory: ${{ env.working-directory }}
 
       - name: Export environment variables

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,21 +14,9 @@ RUN apk add --upgrade --no-cache --virtual .build-deps \
     librdkafka-dev \
     asio-dev
 
-# Dependencies that are not needed if asn1c is not installed in the build container:
-# libtool
-# automake
-# autoconf
-# bison
-# flex
-
 # Install pugixml
 ADD ./pugixml /asn1_codec/pugixml
 RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && make install
-
-# The codec C files are pre-generated manually so it isn't necessary to build asn1c in the container
-# # Build and install asn1c submodule
-# ADD ./usdot-asn1c /asn1_codec/asn1c
-# RUN cd asn1c && test -f configure || autoreconf -iv && ./configure && make && make install
 
 # Make generated files available to the build & compile example
 RUN export LD_LIBRARY_PATH=/usr/local/lib

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -19,10 +19,6 @@ RUN dnf --enablerepo=fedora install asio-devel -y
 ADD ./pugixml /asn1_codec/pugixml
 RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && make install
 
-# Don't need to build and install asn1c submodule
-# ADD ./asn1_codec/usdot-asn1c /asn1_codec/asn1c
-# RUN cd asn1c && test -f configure || autoreconf -iv && ./configure && make && make install
-
 # Make generated files available to the build & compile example
 RUN export LD_LIBRARY_PATH=/usr/local/lib
 ADD ./asn1c_combined /asn1_codec/asn1c_combined

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -14,21 +14,9 @@ RUN apk add --upgrade --no-cache --virtual .build-deps \
     librdkafka-dev \
     asio-dev
 
-# Dependencies that are not needed if asn1c is not installed in the build container:
-# libtool
-# automake
-# autoconf
-# bison
-# flex
-
 # Install pugixml
 ADD ./pugixml /asn1_codec/pugixml
 RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && make install
-
-# The codec C files are pre-generated manually so it isn't necessary to build asn1c in the container
-# # Build and install asn1c submodule
-# ADD ./usdot-asn1c /asn1_codec/asn1c
-# RUN cd asn1c && test -f configure || autoreconf -iv && ./configure && make && make install
 
 # Make generated files available to the build & compile example
 RUN export LD_LIBRARY_PATH=/usr/local/lib

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -14,21 +14,9 @@ RUN apk add --upgrade --no-cache --virtual .build-deps \
     librdkafka-dev \
     asio-dev
 
-# Dependencies that are not needed if asn1c is not installed in the build container:
-# libtool
-# automake
-# autoconf
-# bison
-# flex
-
 # Install pugixml
 ADD ./pugixml /asn1_codec/pugixml
 RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && make install
-
-# The codec C files are pre-generated manually so it isn't necessary to build asn1c in the container
-# # Build and install asn1c submodule
-# ADD ./usdot-asn1c /asn1_codec/asn1c
-# RUN cd asn1c && test -f configure || autoreconf -iv && ./configure && make && make install
 
 # Make generated files available to the build & compile example
 RUN export LD_LIBRARY_PATH=/usr/local/lib

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -13,21 +13,9 @@ RUN apk add --upgrade --no-cache --virtual .build-deps \
     librdkafka-dev \
     asio-dev
 
-# Dependencies that are not needed if asn1c is not installed in the build container:
-# libtool
-# automake
-# autoconf
-# bison
-# flex
-
 # Install pugixml
 ADD ./pugixml /asn1_codec/pugixml
 RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && make install
-
-# The codec C files are pre-generated manually so it isn't necessary to build asn1c in the container
-# # Build and install asn1c submodule
-# ADD ./usdot-asn1c /asn1_codec/asn1c
-# RUN cd asn1c && test -f configure || autoreconf -iv && ./configure && make && make install
 
 # Make generated files available to the build & compile example
 RUN export LD_LIBRARY_PATH=/usr/local/lib

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -14,21 +14,9 @@ RUN apk add --upgrade --no-cache --virtual .build-deps \
     librdkafka-dev \
     asio-dev
 
-# Dependencies that are not needed if asn1c is not installed in the build container:
-# libtool
-# automake
-# autoconf
-# bison
-# flex
-
 # Install pugixml
 ADD ./pugixml /asn1_codec/pugixml
 RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && make install
-
-# The codec C files are pre-generated manually so it isn't necessary to build asn1c in the container
-# # Build and install asn1c submodule
-# ADD ./usdot-asn1c /asn1_codec/asn1c
-# RUN cd asn1c && test -f configure || autoreconf -iv && ./configure && make && make install
 
 # Make generated files available to the build & compile example
 RUN export LD_LIBRARY_PATH=/usr/local/lib


### PR DESCRIPTION
## Problem
Previously, the `doIt.sh` script was updated to extract already-compiled header/implementation files rather than compiling them using asn1c. This decoupled the compilation process from the Docker build process, and the relevant asn1c installation instructions were commented out in the Dockerfiles. These commented-out instructions remain, cluttering the files.

## Solution
Removed all commented-out commands and contextual comments related to asn1c installation from all Dockerfiles to improve readability and maintainability. No active commands, configurations, or environment settings were changed.

## Testing
- Verified that `docker build` completes successfully for each Dockerfile.
- No functional changes were made, so no re-verification of image functionality is required.

## Other Changes
- A dependency was added to the `ci.yml` to fix a CI check failure.
- The asn1c installation steps were removed from the `ci.yml` file since they are no longer required for the `doIt.sh` script.
