### PR TITLE
Optimize Docker build by introducing shared `runtime-deps` stage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,6 @@ asn1c_combined/libasncodec.a
 # Ignore files added by CLion
 .idea/
 cmake-build-*/
+
+# Ignore Python bytecode files (generated during `do_kafka_test.sh` execution)
+*.pyc

--- a/Dockerfile.amazonlinux
+++ b/Dockerfile.amazonlinux
@@ -1,15 +1,26 @@
-# === BUILDER IMAGE for ACM ===
-FROM amazonlinux:2023 as builder
+# === RUNTIME DEPENDENCIES IMAGE ===
+FROM amazonlinux:2023 as runtime-deps
 USER root
 WORKDIR /asn1_codec
-## add build dependencies
-RUN yum install -y cmake g++ make bash automake libtool autoconf
+VOLUME ["/asn1_codec_share"]
+
+# # add runtime dependencies
+RUN yum install -y bash
 
 # Install librdkafka from Confluent repo
 RUN rpm --import https://packages.confluent.io/rpm/7.6/archive.key
 COPY ./confluent.repo /etc/yum.repos.d
 RUN yum clean all
 RUN yum install -y librdkafka-devel
+
+
+# === BUILDER IMAGE for ACM ===
+FROM runtime-deps as builder
+USER root
+WORKDIR /asn1_codec
+
+## add build dependencies
+RUN yum install -y cmake g++ make bash automake libtool autoconf
 
 # Install asio from Fedora repo (build dependency only)
 COPY ./fedora.repo /etc/yum.repos.d
@@ -46,21 +57,11 @@ ADD ./data /asn1_codec/data
 RUN mkdir -p /build && cd /build && cmake /asn1_codec && make
 
 
-
 # === RUNTIME IMAGE ===
-FROM amazonlinux:2023
+FROM runtime-deps
 USER root
 WORKDIR /asn1_codec
 VOLUME ["/asn1_codec_share"]
-
-# # add runtime dependencies
-RUN yum install -y bash
-
-# Install librdkafka from Confluent repo
-RUN rpm --import https://packages.confluent.io/rpm/7.6/archive.key
-COPY ./confluent.repo /etc/yum.repos.d
-RUN yum clean all
-RUN yum install -y librdkafka-devel
 
 # # copy the built files from the builder
 COPY --from=builder /asn1_codec /asn1_codec

--- a/Dockerfile.debug
+++ b/Dockerfile.debug
@@ -1,5 +1,18 @@
+# === RUNTIME DEPENDENCIES IMAGE ===
+FROM alpine:3.18 as runtime-deps
+USER root
+WORKDIR /asn1_codec
+VOLUME ["/asn1_codec_share"]
+
+# add runtime dependencies
+RUN apk add --upgrade --no-cache \
+    bash \
+    librdkafka \
+    librdkafka-dev
+
+
 # === BUILDER IMAGE ===
-FROM alpine:3.18 as builder
+FROM runtime-deps as builder
 USER root
 WORKDIR /asn1_codec
 VOLUME ["/asn1_codec_share"]
@@ -9,9 +22,6 @@ RUN apk add --upgrade --no-cache --virtual .build-deps \
     cmake \
     g++ \
     make \
-    bash \
-    librdkafka \
-    librdkafka-dev \
     asio-dev
 
 # Install pugixml
@@ -22,8 +32,6 @@ RUN cd /asn1_codec/pugixml && mkdir -p build && cd build && cmake .. && make && 
 RUN export LD_LIBRARY_PATH=/usr/local/lib
 ADD ./asn1c_combined /asn1_codec/asn1c_combined
 RUN cd /asn1_codec/asn1c_combined && bash doIt.sh
-
-
 
 # Remove any lingering .asn files
 RUN rm -rf /asn1c_codec/asn1c_combined/j2735-asn-files
@@ -53,19 +61,11 @@ RUN echo "export CC=gcc" >> ~/.bashrc
 RUN mkdir -p /build && cd /build && cmake /asn1_codec && make
 
 
-
-
 # === RUNTIME IMAGE ===
-FROM alpine:3.18
+FROM runtime-deps
 USER root
 WORKDIR /asn1_codec
 VOLUME ["/asn1_codec_share"]
-
-# add runtime dependencies
-RUN apk add --upgrade --no-cache \
-    bash \
-    librdkafka \
-    librdkafka-dev
 
 # Use jemalloc
 RUN apk add --upgrade --no-cache jemalloc

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -1,5 +1,18 @@
+# === RUNTIME DEPENDENCIES IMAGE ===
+FROM alpine:3.18 as runtime-deps
+USER root
+WORKDIR /asn1_codec
+VOLUME ["/asn1_codec_share"]
+
+# add runtime dependencies
+RUN apk add --upgrade --no-cache \
+    bash \
+    librdkafka \
+    librdkafka-dev
+
+
 # === BUILDER IMAGE ===
-FROM alpine:3.18 as builder
+FROM runtime-deps as builder
 USER root
 WORKDIR /asn1_codec
 VOLUME ["/asn1_codec_share"]
@@ -9,9 +22,6 @@ RUN apk add --upgrade --no-cache --virtual .build-deps \
     cmake \
     g++ \
     make \
-    bash \
-    librdkafka \
-    librdkafka-dev \
     asio-dev
 
 # Install pugixml
@@ -49,17 +59,12 @@ RUN echo "export CC=gcc" >> ~/.bashrc
 # Build acm.
 RUN mkdir -p /build && cd /build && cmake /asn1_codec && make
 
+
 # === RUNTIME IMAGE ===
-FROM alpine:3.18
+FROM runtime-deps
 USER root
 WORKDIR /asn1_codec
 VOLUME ["/asn1_codec_share"]
-
-# add runtime dependencies
-RUN apk add --upgrade --no-cache \
-    bash \
-    librdkafka \
-    librdkafka-dev
 
 # Use jemalloc
 RUN apk add --upgrade --no-cache jemalloc

--- a/Dockerfile.standalone
+++ b/Dockerfile.standalone
@@ -1,5 +1,18 @@
+# === RUNTIME DEPENDENCIES IMAGE ===
+FROM alpine:3.18 as runtime-deps
+USER root
+WORKDIR /asn1_codec
+VOLUME ["/asn1_codec_share"]
+
+# add runtime dependencies
+RUN apk add --upgrade --no-cache \
+    bash \
+    librdkafka \
+    librdkafka-dev
+
+
 # === BUILDER IMAGE ===
-FROM alpine:3.18 as builder
+FROM runtime-deps as builder
 USER root
 WORKDIR /asn1_codec
 
@@ -8,9 +21,6 @@ RUN apk add --upgrade --no-cache --virtual .build-deps \
     cmake \
     g++ \
     make \
-    bash \
-    librdkafka \
-    librdkafka-dev \
     asio-dev
 
 # Install pugixml
@@ -43,16 +53,11 @@ ADD ./data /asn1_codec/data
 # Build acm.
 RUN mkdir -p /build && cd /build && cmake /asn1_codec && make
 
+
 # === RUNTIME IMAGE ===
-FROM alpine:3.18
+FROM runtime-deps
 USER root
 WORKDIR /asn1_codec
-
-# add runtime dependencies
-RUN apk add --upgrade --no-cache \
-    bash \
-    librdkafka \
-    librdkafka-dev
 
 # Use jemalloc
 RUN apk add --upgrade --no-cache jemalloc

--- a/Dockerfile.testing
+++ b/Dockerfile.testing
@@ -1,5 +1,19 @@
+# === RUNTIME DEPENDENCIES IMAGE ===
+FROM alpine:3.18 as runtime-deps
+USER root
+WORKDIR /asn1_codec
+VOLUME ["/asn1_codec_share"]
+
+# add runtime dependencies
+RUN apk add --upgrade --no-cache \
+    bash \
+    python3 \
+    librdkafka \
+    librdkafka-dev
+
+
 # === BUILDER IMAGE ===
-FROM alpine:3.18 as builder
+FROM runtime-deps as builder
 USER root
 WORKDIR /asn1_codec
 VOLUME ["/asn1_codec_share"]
@@ -9,9 +23,6 @@ RUN apk add --upgrade --no-cache --virtual .build-deps \
     cmake \
     g++ \
     make \
-    bash \
-    librdkafka \
-    librdkafka-dev \
     asio-dev
 
 # Install pugixml
@@ -52,17 +63,10 @@ RUN echo "export CC=gcc" >> ~/.bashrc
 RUN mkdir -p /build && cd /build && cmake /asn1_codec && make
 
 # === RUNTIME IMAGE ===
-FROM alpine:3.18
+FROM runtime-deps
 USER root
 WORKDIR /asn1_codec
 VOLUME ["/asn1_codec_share"]
-
-# add runtime dependencies
-RUN apk add --upgrade --no-cache \
-    bash \
-    python3 \
-    librdkafka \
-    librdkafka-dev
 
 # Use jemalloc
 RUN apk add --upgrade --no-cache jemalloc

--- a/do_kafka_test.sh
+++ b/do_kafka_test.sh
@@ -53,7 +53,7 @@ waitForKafkaToCreateTopics() {
             echo "Kafka container not running yet (attempt $attempts/$maxAttempts)..."
         else
             # try a non-interactive topics list to confirm broker is responsive
-            if docker exec "$KAFKA_CONTAINER_NAME" /opt/kafka/bin/kafka-topics.sh --list --zookeeper 172.17.0.1 >/dev/null 2>&1; then
+            if docker exec "$KAFKA_CONTAINER_NAME" /opt/kafka/bin/kafka-topics.sh --list --zookeeper $DOCKER_HOST_IP >/dev/null 2>&1; then
                 echo "Kafka broker responded on container '$KAFKA_CONTAINER_NAME'"
                 break
             else
@@ -79,7 +79,7 @@ waitForKafkaToCreateTopics() {
             exit 1
         fi
 
-        ltopics=$(docker exec "$KAFKA_CONTAINER_NAME" /opt/kafka/bin/kafka-topics.sh --list --zookeeper 172.17.0.1 2>/dev/null || true)
+        ltopics=$(docker exec "$KAFKA_CONTAINER_NAME" /opt/kafka/bin/kafka-topics.sh --list --zookeeper $DOCKER_HOST_IP 2>/dev/null || true)
         allTopicsCreated=true
         if [ $(echo "$ltopics" | grep "topic.Asn1DecoderInput" | wc -l) = "0" ]; then
             allTopicsCreated=false

--- a/do_kafka_test.sh
+++ b/do_kafka_test.sh
@@ -41,6 +41,8 @@ setup() {
 }
 
 waitForKafkaToCreateTopics() {
+    sleep 1 # give Kafka a moment to start
+
     maxAttempts=100
     attempts=0
     KAFKA_CONTAINER_NAME=$(docker ps --format '{{.Names}}' | grep kafka)


### PR DESCRIPTION
## Problem
Runtime dependencies were being installed separately in both the builder and runtime images. This duplication increased build times and added unnecessary complexity.

## Solution
A new intermediate build stage, `runtime-deps`, has been added. Both the builder and runtime stages now reference this shared stage instead of installing runtime dependencies independently.

## Testing
- Verified `do_kafka_test.sh` script completes successfully
- Confirmed all Dockerfile variants build without errors
- Ensured the application starts up as expected
- Verified BSM decoding functions correctly

## Additional Changes
- An entry to `.gitignore` was added for .pyc files
- A health check was added to `do_kafka_test.sh` to give Kafka a moment to start before checking for topics